### PR TITLE
Persist glTF shaders

### DIFF
--- a/code/glTFAsset.h
+++ b/code/glTFAsset.h
@@ -948,12 +948,9 @@ namespace glTF
         Ref<Program> program;
         States states;
 
-        // We'll cache a JSON string of this technique with its dependencies inlined, which will itself be cached on
-        // materials that use this technique.
-        std::string json;
-
         Technique() {}
         void Read(Value& obj, Asset& r);
+        std::string ToJSON();
     };
 
     //! A texture and its sampler.

--- a/code/glTFAsset.h
+++ b/code/glTFAsset.h
@@ -1182,12 +1182,12 @@ namespace glTF
         LazyDict<Material>    materials;
         LazyDict<Mesh>        meshes;
         LazyDict<Node>        nodes;
-        LazyDict<Program>   programs;
+        LazyDict<Program>     programs;
         LazyDict<Sampler>     samplers;
         LazyDict<Scene>       scenes;
-        LazyDict<Shader>    shaders;
-        LazyDict<Skin>      skins;
-        LazyDict<Technique> techniques;
+        LazyDict<Shader>      shaders;
+        LazyDict<Skin>        skins;
+        LazyDict<Technique>   techniques;
         LazyDict<Texture>     textures;
 
         LazyDict<Light>       lights; // KHR_materials_common ext
@@ -1207,12 +1207,12 @@ namespace glTF
             , materials     (*this, "materials")
             , meshes        (*this, "meshes")
             , nodes         (*this, "nodes")
-            , programs    (*this, "programs")
+            , programs      (*this, "programs")
             , samplers      (*this, "samplers")
             , scenes        (*this, "scenes")
-            , shaders     (*this, "shaders")
-            , skins       (*this, "skins")
-            , techniques  (*this, "techniques")
+            , shaders       (*this, "shaders")
+            , skins         (*this, "skins")
+            , techniques    (*this, "techniques")
             , textures      (*this, "textures")
             , lights        (*this, "lights", "KHR_materials_common")
         {

--- a/code/glTFAsset.inl
+++ b/code/glTFAsset.inl
@@ -677,6 +677,10 @@ inline void Image::SetData(uint8_t* data, size_t length, Asset& r)
 
 inline void Program::Read(Value& obj, Asset& r)
 {
+    if (Value* nm = FindString(obj, "name")) {
+        name = nm->GetString();
+    }
+
     if (Value* attrs = FindArray(obj, "attributes")) {
         for (size_t i = 0; i < attrs->Size(); ++i) {
             Value& attr = (*attrs)[i];
@@ -721,6 +725,10 @@ inline void Shader::Read(Value& obj, Asset& /*r*/)
 
 inline void Technique::Read(Value& obj, Asset& r)
 {
+    if (Value* nm = FindString(obj, "name")) {
+        name = nm->GetString();
+    }
+
     if (Value* attrs = FindObject(obj, "attributes")) {
         for (Value::MemberIterator it = attrs->MemberBegin(); it != attrs->MemberEnd(); ++it) {
             if (it->value.IsString())
@@ -769,6 +777,9 @@ inline std::string Technique::ToJSON()
 
     w.StartObject();
 
+    w.Key("name");
+    w.String(this->id);
+
     w.Key("attributes");
     w.StartObject();
     for (const auto& attr : attributes) {
@@ -804,6 +815,9 @@ inline std::string Technique::ToJSON()
         w.Key("program");
         w.StartObject();
 
+        w.Key("name");
+        w.String(program->id);
+
         w.Key("attributes");
         w.StartArray();
         for (const std::string& attr : program->attributes) {
@@ -813,6 +827,8 @@ inline std::string Technique::ToJSON()
 
         w.Key("fragmentShader");
         w.StartObject();
+        w.Key("name");
+        w.String(program->fragmentShader->id);
         w.Key("uri");
         w.String(program->fragmentShader->uri);
         w.Key("type");
@@ -821,6 +837,8 @@ inline std::string Technique::ToJSON()
 
         w.Key("vertexShader");
         w.StartObject();
+        w.Key("name");
+        w.String(program->vertexShader->id);
         w.Key("uri");
         w.String(program->vertexShader->uri);
         w.Key("type");

--- a/code/glTFAssetWriter.inl
+++ b/code/glTFAssetWriter.inl
@@ -249,6 +249,10 @@ namespace glTF {
             v.AddMember("shininess", m.shininess, w.mAl);
         }
         obj.AddMember("values", v, w.mAl);
+
+        if (m.technique) {
+            obj.AddMember("technique", Value(m.technique->id, w.mAl).Move(), w.mAl);
+        }
     }
 
     namespace {
@@ -400,7 +404,12 @@ namespace glTF {
 
     inline void Write(Value& obj, Program& b, AssetWriter& w)
     {
-
+        if (b.fragmentShader) {
+            obj.AddMember("fragmentShader", b.fragmentShader->id, w.mAl);
+        }
+        if (b.vertexShader) {
+            obj.AddMember("vertexShader", b.vertexShader->id, w.mAl);
+        }
     }
 
     inline void Write(Value& obj, Sampler& b, AssetWriter& w)
@@ -426,7 +435,10 @@ namespace glTF {
 
     inline void Write(Value& obj, Shader& b, AssetWriter& w)
     {
-
+        if (!b.uri.empty()) {
+            obj.AddMember("uri", b.uri, w.mAl);
+        }
+        obj.AddMember("type", b.type, w.mAl);
     }
 
     inline void Write(Value& obj, Skin& b, AssetWriter& w)
@@ -454,7 +466,57 @@ namespace glTF {
 
     inline void Write(Value& obj, Technique& b, AssetWriter& w)
     {
+        if (!b.attributes.empty()) {
+            Value attrs;
+            attrs.SetObject();
+            for (const auto& attr : b.attributes) {
+                attrs.AddMember(StringRef(attr.first), StringRef(attr.second), w.mAl);
+            }
+            obj.AddMember("attributes", attrs, w.mAl);
+        }
 
+        if (!b.uniforms.empty()) {
+            Value unis;
+            unis.SetObject();
+            for (const auto& uniform : b.uniforms) {
+                unis.AddMember(StringRef(uniform.first), StringRef(uniform.second), w.mAl);
+            }
+            obj.AddMember("uniforms", unis, w.mAl);
+        }
+
+        if (!b.parameters.empty()) {
+            Value params;
+            params.SetObject();
+            for (const auto& parameter : b.parameters) {
+                Value param;
+                param.SetObject();
+                param.AddMember("type", parameter.type, w.mAl);
+                if (!parameter.semantic.empty()) {
+                    param.AddMember("semantic", parameter.semantic, w.mAl);
+                }
+
+                params.AddMember(StringRef(parameter.name), param, w.mAl);
+            }
+            obj.AddMember("parameters", params, w.mAl);
+        }
+
+        if (b.program) {
+            obj.AddMember("program", b.program->id, w.mAl);
+        }
+
+        if (!b.states.enable.empty()) {
+            Value states;
+            states.SetObject();
+
+            Value enables;
+            enables.SetArray();
+            for (WebGLState state : b.states.enable) {
+                enables.PushBack(state, w.mAl);
+            }
+            states.AddMember("enable", enables, w.mAl);
+
+            obj.AddMember("states", states, w.mAl);
+        }
     }
 
     inline void Write(Value& obj, Texture& tex, AssetWriter& w)

--- a/code/glTFExporter.cpp
+++ b/code/glTFExporter.cpp
@@ -67,6 +67,8 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #	include <Open3DGC/o3dgcSC3DMCEncoder.h>
 #endif
 
+#include <rapidjson/document.h>
+
 using namespace rapidjson;
 
 using namespace Assimp;
@@ -368,6 +370,40 @@ void glTFExporter::ExportMaterials()
         m->transparent = mat->Get(AI_MATKEY_OPACITY, m->transparency) == aiReturn_SUCCESS && m->transparency != 1.0;
 
         GetMatScalar(mat, m->shininess, AI_MATKEY_SHININESS);
+
+        std::string techniqueJSON;
+        aiString ait;
+        if (mat->Get("$mat.gltf.technique", 0, 0, ait) == AI_SUCCESS) {
+            techniqueJSON = ait.C_Str();
+            std::string techniqueName = mAsset->FindUniqueID("", "technique");
+            m->technique = mAsset->techniques.Create(techniqueName);
+
+            Document techniqueDoc;
+            techniqueDoc.Parse(techniqueJSON.c_str());
+
+            m->technique->Read(techniqueDoc, *mAsset);
+
+            if (Value* programObj = FindObject(techniqueDoc, "program")) {
+                std::string programName = mAsset->FindUniqueID("", "program");
+                Ref<Program> program = mAsset->programs.Create(programName);
+                program->Read(*programObj, *mAsset);
+                m->technique->program = program;
+
+                if (Value* fsObj = FindObject(*programObj, "fragmentShader")) {
+                    std::string fsName = mAsset->FindUniqueID("", "fs");
+                    Ref<Shader> fs = mAsset->shaders.Create(fsName);
+                    fs->Read(*fsObj, *mAsset);
+                    program->fragmentShader = fs;
+                }
+
+                if (Value* vsObj = FindObject(*programObj, "vertexShader")) {
+                    std::string vsName = mAsset->FindUniqueID("", "vs");
+                    Ref<Shader> vs = mAsset->shaders.Create(vsName);
+                    vs->Read(*vsObj, *mAsset);
+                    program->vertexShader = vs;
+                }
+            }
+        }
     }
 }
 

--- a/code/glTFExporter.cpp
+++ b/code/glTFExporter.cpp
@@ -376,19 +376,44 @@ void glTFExporter::ExportMaterials()
             if (prop->mKey != aiString("$mat.gltf.technique")) {
                 continue;
             }
-            std::string techniqueName = mAsset->FindUniqueID("", "technique");
-            m->technique = mAsset->techniques.Create(techniqueName);
 
-            char jsonBlob[prop->mDataLength + 1];
-            strncpy(jsonBlob, prop->mData, prop->mDataLength);
-            jsonBlob[prop->mDataLength] = '\0';
+            std::string jsonBlob;
+            for (size_t c = 0; c < prop->mDataLength; ++c) {
+                jsonBlob += prop->mData[c];
+            }
 
             Document techniqueDoc;
-            techniqueDoc.Parse(jsonBlob);
+            techniqueDoc.Parse(jsonBlob.c_str());
+
+            if (Value* name = FindString(techniqueDoc, "name")) {
+                Ref<Technique> technique;
+                for (size_t i = 0; i < mAsset->techniques.Size(); ++i) {
+                    if (mAsset->techniques[i].name == name->GetString())
+                        technique = mAsset->techniques.Get(i);
+                }
+                if (technique) {
+                    m->technique = technique;
+                    continue;
+                }
+            }
+
+            std::string techniqueName = mAsset->FindUniqueID("", "technique");
+            m->technique = mAsset->techniques.Create(techniqueName);
 
             m->technique->Read(techniqueDoc, *mAsset);
 
             if (Value* programObj = FindObject(techniqueDoc, "program")) {
+                if (Value* name = FindString(*programObj, "name")) {
+                    Ref<Program> program;
+                    for (size_t i = 0; i < mAsset->programs.Size(); ++i) {
+                        if (mAsset->programs[i].name == name->GetString())
+                            program = mAsset->programs.Get(i);
+                    }
+                    if (program) {
+                        m->technique->program = program;
+                        continue;
+                    }
+                }
                 std::string programName = mAsset->FindUniqueID("", "program");
                 Ref<Program> program = mAsset->programs.Create(programName);
                 program->Read(*programObj, *mAsset);

--- a/code/glTFExporter.cpp
+++ b/code/glTFExporter.cpp
@@ -371,15 +371,20 @@ void glTFExporter::ExportMaterials()
 
         GetMatScalar(mat, m->shininess, AI_MATKEY_SHININESS);
 
-        std::string techniqueJSON;
-        aiString ait;
-        if (mat->Get("$mat.gltf.technique", 0, 0, ait) == AI_SUCCESS) {
-            techniqueJSON = ait.C_Str();
+        for (size_t i = 0; i < mat->mNumProperties; ++i) {
+            aiMaterialProperty *prop = mat->mProperties[i];
+            if (prop->mKey != aiString("$mat.gltf.technique")) {
+                continue;
+            }
             std::string techniqueName = mAsset->FindUniqueID("", "technique");
             m->technique = mAsset->techniques.Create(techniqueName);
 
+            char jsonBlob[prop->mDataLength + 1];
+            strncpy(jsonBlob, prop->mData, prop->mDataLength);
+            jsonBlob[prop->mDataLength] = '\0';
+
             Document techniqueDoc;
-            techniqueDoc.Parse(techniqueJSON.c_str());
+            techniqueDoc.Parse(jsonBlob);
 
             m->technique->Read(techniqueDoc, *mAsset);
 

--- a/code/glTFImporter.cpp
+++ b/code/glTFImporter.cpp
@@ -198,6 +198,12 @@ void glTFImporter::ImportMaterials(glTF::Asset& r)
             aimat->AddProperty(&str, AI_MATKEY_NAME);
         }
 
+        if (mat.technique) {
+            std::string json = mat.technique->ToJSON();
+            aiString ais(json);
+            aimat->AddProperty(&ais, "$mat.gltf.technique", 0, 0);
+        }
+
         SetMaterialColorProperty(embeddedTexIdxs, r, mat.diffuse, aimat, aiTextureType_DIFFUSE, AI_MATKEY_COLOR_DIFFUSE);
         SetMaterialColorProperty(embeddedTexIdxs, r, mat.specular, aimat, aiTextureType_SPECULAR, AI_MATKEY_COLOR_SPECULAR);
         SetMaterialColorProperty(embeddedTexIdxs, r, mat.ambient, aimat, aiTextureType_AMBIENT, AI_MATKEY_COLOR_AMBIENT);

--- a/code/glTFImporter.cpp
+++ b/code/glTFImporter.cpp
@@ -200,8 +200,7 @@ void glTFImporter::ImportMaterials(glTF::Asset& r)
 
         if (mat.technique) {
             std::string json = mat.technique->ToJSON();
-            aiString ais(json);
-            aimat->AddProperty(&ais, "$mat.gltf.technique", 0, 0);
+            aimat->AddBinaryProperty(json.c_str(), json.size(), "$mat.gltf.technique", 0, 0, aiPTI_Buffer);
         }
 
         SetMaterialColorProperty(embeddedTexIdxs, r, mat.diffuse, aimat, aiTextureType_DIFFUSE, AI_MATKEY_COLOR_DIFFUSE);


### PR DESCRIPTION
Here we serialize glTF `technique` nodes as JSON, inlining dependencies, persist the JSON as a property in corresponding `aiMaterial` instances, and export them in the `glTFExporter` when present.