### PR TITLE
Persist "node" and "count" properties of technique.parameters

### DIFF
--- a/code/glTFAsset.h
+++ b/code/glTFAsset.h
@@ -935,6 +935,8 @@ namespace glTF
             std::string name;
             std::string semantic;
             ParameterType type;
+            size_t count;
+            std::string node;
         };
 
         struct States

--- a/code/glTFAsset.inl
+++ b/code/glTFAsset.inl
@@ -754,6 +754,12 @@ inline void Technique::Read(Value& obj, Asset& r)
             newParam.type = MemberOrDefault(it->value, "type", ParameterType_FLOAT);
             if (Value* sem = FindString(it->value, "semantic"))
                 newParam.semantic = sem->GetString();
+            if (Value* nd = FindString(it->value, "node"))
+                newParam.node = nd->GetString();
+            if (Value* cnt = FindInt(it->value, "count"))
+                newParam.count = cnt->GetInt();
+            else
+                newParam.count = 1;
 
             parameters.push_back(newParam);
         }
@@ -806,6 +812,14 @@ inline std::string Technique::ToJSON()
         if (!param.semantic.empty()) {
             w.Key("semantic");
             w.String(param.semantic);
+        }
+        if (param.count != 1) {
+            w.Key("count");
+            w.Uint(param.count);
+        }
+        if (!param.node.empty()) {
+            w.Key("node");
+            w.String(param.node);
         }
         w.EndObject();
     }

--- a/code/glTFAssetWriter.inl
+++ b/code/glTFAssetWriter.inl
@@ -494,6 +494,12 @@ namespace glTF {
                 if (!parameter.semantic.empty()) {
                     param.AddMember("semantic", parameter.semantic, w.mAl);
                 }
+                if (!parameter.node.empty()) {
+                    param.AddMember("node", parameter.node, w.mAl);
+                }
+                if (parameter.count != 1) {
+                    param.AddMember("count", parameter.count, w.mAl);
+                }
 
                 params.AddMember(StringRef(parameter.name), param, w.mAl);
             }


### PR DESCRIPTION
We use the "node" property on the frontend to avoid mapping parameters associated with a node to THREE.js's top-level attributes and uniforms.